### PR TITLE
proto: bootstrap AgentRuntimeService contract

### DIFF
--- a/.github/workflows/proto-ci.yml
+++ b/.github/workflows/proto-ci.yml
@@ -1,0 +1,14 @@
+name: proto-ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+      - run: buf lint

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,11 @@
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/go
+    out: gen/go
+    opt: paths=source_relative
+  - remote: buf.build/grpc/go
+    out: gen/go
+    opt: paths=source_relative
+  - remote: buf.build/bufbuild/es
+    out: gen/ts
+    opt: target=ts

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,9 @@
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,14 @@
+# Gateway ↔ PicoClaw Agent Contract
+
+`agsale-agent-proto` is the source of truth for gRPC/protobuf contracts between:
+
+- `agsale-backend` Gateway
+- `picoclaw-agent-svc` PicoClaw wrapper
+
+Rules:
+
+1. Gateway owns persistence, routing, and outbound dispatch.
+2. PicoClaw never sends channel messages directly.
+3. Gateway calls PicoClaw through `AgentRuntimeService` only.
+4. `ProcessInbound` is MVP RPC.
+5. `human_only` should not require PicoClaw; `assist_only` returns suggested reply; `bot_auto_reply` returns sendable reply or escalation.

--- a/proto/agsale/agent/v1/action.proto
+++ b/proto/agsale/agent/v1/action.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package agsale.agent.v1;
+
+option go_package = "github.com/hongta0506/agsale-agent-proto/gen/go/agsale/agent/v1;agentv1";
+
+enum AgentDecisionType {
+  AGENT_DECISION_TYPE_UNSPECIFIED = 0;
+  AGENT_DECISION_TYPE_NO_ACTION = 1;
+  AGENT_DECISION_TYPE_SUGGEST_REPLY = 2;
+  AGENT_DECISION_TYPE_SEND_REPLY = 3;
+  AGENT_DECISION_TYPE_ESCALATE_TO_HUMAN = 4;
+}
+
+enum AgentActionType {
+  AGENT_ACTION_TYPE_UNSPECIFIED = 0;
+  AGENT_ACTION_TYPE_CREATE_FOLLOW_UP = 1;
+  AGENT_ACTION_TYPE_TAG_CONVERSATION = 2;
+  AGENT_ACTION_TYPE_UPDATE_CUSTOMER_PROFILE = 3;
+  AGENT_ACTION_TYPE_UPDATE_LEAD_SCORE = 4;
+  AGENT_ACTION_TYPE_ESCALATE_TO_HUMAN = 5;
+  AGENT_ACTION_TYPE_CREATE_ORDER_DRAFT = 6;
+}
+
+message AgentDecision {
+  AgentDecisionType type = 1;
+  string reason = 2;
+  double confidence = 3;
+}
+
+message AgentAction {
+  AgentActionType type = 1;
+  string payload_json = 2;
+  string reason = 3;
+}

--- a/proto/agsale/agent/v1/agent_runtime.proto
+++ b/proto/agsale/agent/v1/agent_runtime.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package agsale.agent.v1;
+
+option go_package = "github.com/hongta0506/agsale-agent-proto/gen/go/agsale/agent/v1;agentv1";
+
+import "agsale/agent/v1/action.proto";
+import "agsale/agent/v1/common.proto";
+import "agsale/agent/v1/evaluation.proto";
+import "agsale/agent/v1/message.proto";
+
+service AgentRuntimeService {
+  rpc ProcessInbound(ProcessInboundRequest) returns (ProcessInboundResponse);
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+}
+
+message ProcessInboundRequest {
+  RequestContext context = 1;
+  ConversationContext conversation = 2;
+  CustomerContext customer = 3;
+  InboundMessage message = 4;
+  AutomationMode automation_mode = 5;
+  repeated ConversationMessage recent_messages = 6;
+}
+
+message ProcessInboundResponse {
+  AgentDecision decision = 1;
+  ReplyDraft reply = 2;
+  MessageEvaluation message_evaluation = 3;
+  ConversationEvaluation conversation_evaluation = 4;
+  LeadScore lead_score = 5;
+  repeated AgentAction actions = 6;
+  repeated string warnings = 7;
+}
+
+message HealthCheckRequest {}
+
+message HealthCheckResponse {
+  string status = 1;
+  string version = 2;
+}

--- a/proto/agsale/agent/v1/common.proto
+++ b/proto/agsale/agent/v1/common.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package agsale.agent.v1;
+
+option go_package = "github.com/hongta0506/agsale-agent-proto/gen/go/agsale/agent/v1;agentv1";
+
+enum AutomationMode {
+  AUTOMATION_MODE_UNSPECIFIED = 0;
+  AUTOMATION_MODE_HUMAN_ONLY = 1;
+  AUTOMATION_MODE_ASSIST_ONLY = 2;
+  AUTOMATION_MODE_BOT_AUTO_REPLY = 3;
+}
+
+message RequestContext {
+  string request_id = 1;
+  string tenant_id = 2;
+  string workspace_id = 3;
+  string idempotency_key = 4;
+  int64 occurred_at_unix_ms = 5;
+}
+
+message CustomerContext {
+  string customer_id = 1;
+  string display_name = 2;
+  string phone = 3;
+  string external_user_id = 4;
+  repeated string tags = 5;
+}
+
+message ConversationContext {
+  string conversation_id = 1;
+  string channel = 2; // facebook, zalo, telegram, whatsapp
+  string channel_conversation_id = 3;
+  string locale = 4;
+}

--- a/proto/agsale/agent/v1/evaluation.proto
+++ b/proto/agsale/agent/v1/evaluation.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package agsale.agent.v1;
+
+option go_package = "github.com/hongta0506/agsale-agent-proto/gen/go/agsale/agent/v1;agentv1";
+
+message MessageEvaluation {
+  string intent = 1;
+  string sentiment = 2;
+  double urgency_score = 3;
+  double sales_opportunity_score = 4;
+  repeated string tags = 5;
+}
+
+message ConversationEvaluation {
+  string stage = 1;
+  double health_score = 2;
+  bool needs_human = 3;
+  string summary = 4;
+}
+
+message LeadScore {
+  double score = 1;
+  string grade = 2;
+  repeated string reasons = 3;
+}

--- a/proto/agsale/agent/v1/message.proto
+++ b/proto/agsale/agent/v1/message.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package agsale.agent.v1;
+
+option go_package = "github.com/hongta0506/agsale-agent-proto/gen/go/agsale/agent/v1;agentv1";
+
+message InboundMessage {
+  string message_id = 1;
+  string external_message_id = 2;
+  string sender_id = 3;
+  string text = 4;
+  repeated MessageAttachment attachments = 5;
+  int64 sent_at_unix_ms = 6;
+}
+
+message ConversationMessage {
+  string message_id = 1;
+  string sender_type = 2; // customer, staff, bot
+  string text = 3;
+  int64 sent_at_unix_ms = 4;
+}
+
+message MessageAttachment {
+  string type = 1;
+  string url = 2;
+  string mime_type = 3;
+}
+
+message ReplyDraft {
+  string text = 1;
+  repeated MessageAttachment attachments = 2;
+  string language = 3;
+  double confidence = 4;
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+buf lint
+buf generate


### PR DESCRIPTION
## Summary

Bootstrap `agsale-agent-proto` as the shared protobuf/gRPC contract repo for AGSale Gateway ↔ PicoClaw.

Includes:
- Buf config
- MVP `AgentRuntimeService` with `ProcessInbound` and `HealthCheck`
- Common message/evaluation/action proto files
- Contract docs
- Proto CI

## Integration intent

- Gateway imports generated Go package from this repo.
- PicoClaw wrapper implements `AgentRuntimeService` from this proto.
- Gateway remains the only outbound channel dispatcher.